### PR TITLE
fixing Vyper contract to work

### DIFF
--- a/contracts/VyperStorage.vy
+++ b/contracts/VyperStorage.vy
@@ -1,14 +1,16 @@
+# @version >=0.2.7 <0.3.0
+
 stored_data: public(uint256)
 
-@public
+@external
 def __init__():
     self.stored_data = 10
 
-@public
+@external
 def set(_x: uint256):
     self.stored_data = _x
 
-@public
-@constant
+@external
+@view
 def get() -> uint256:
     return self.stored_data


### PR DESCRIPTION
Mix was not able to be run with the directions in the README on newer systems.  Fixing the contract with updated Vyper.